### PR TITLE
Uppdatera voice-kod, lägg till !faxify

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:openrouter.ai)"
+    ]
+  }
+}

--- a/farsbot.py
+++ b/farsbot.py
@@ -169,6 +169,7 @@ async def call_openrouter(api_key, original_image_uri, grid_image_uri, prompt):
             result = await resp.json()
     images = result["choices"][0]["message"].get("images", [])
     if not images:
+        logging.warning("OpenRouter returned no images. Response: %s", result)
         return None
     b64_url = images[0]["image_url"]["url"]
     # Strip the data URI prefix

--- a/farsbot.py
+++ b/farsbot.py
@@ -23,7 +23,7 @@ nest_asyncio.apply()
 logging.basicConfig(filename="farsbot.log", level=logging.DEBUG)
 
 FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second. Each face in the first image should be replace with exactly one face from the second image. Remove background from the faces in the second image if needed."
-OPENROUTER_MODEL = "google/gemini-3.1-flash-image-preview"
+OPENROUTER_MODEL = "bytedance-seed/seedream-4.5"
 
 user_id_anders = 801923008532578354
 user_id_fritjof = 560877870076133378
@@ -182,6 +182,7 @@ class FarsBot(commands.Cog):
         self.bot = bot
         self.queue = []
         self.openrouter_key = load_openrouter_key()
+        self._voice_connecting = False
 
     def check_queue(self, client):
         if len(self.queue) > 0:
@@ -418,13 +419,16 @@ class FarsBot(commands.Cog):
                 )
                 
                 if not bot_in_channel:
+                    if self._voice_connecting:
+                        return
+                    self._voice_connecting = True
                     # Bot should join the channel
                     try:
                         voice_client = await after.channel.connect()
-                        
+
                         # Wait a moment for connection to stabilize
                         await asyncio.sleep(0.5)
-                        
+
                         # Determine which sound to play
                         soundPath = self.get_user_sound(member.id)
 
@@ -438,6 +442,8 @@ class FarsBot(commands.Cog):
                         )
                     except Exception as e:
                         print(f"Error joining channel: {e}")
+                    finally:
+                        self._voice_connecting = False
                 else:
                     # Bot is already in the channel, just play the sound
                     for vc in self.bot.voice_clients:

--- a/farsbot.py
+++ b/farsbot.py
@@ -22,7 +22,7 @@ import re
 nest_asyncio.apply()
 logging.basicConfig(filename="farsbot.log", level=logging.DEBUG)
 
-FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second."
+FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second. Each face in the first image should be replace with exactly one face from the second image. Remove background from the faces in the second image if needed."
 OPENROUTER_MODEL = "google/gemini-3.1-flash-image-preview"
 
 user_id_anders = 801923008532578354

--- a/farsbot.py
+++ b/farsbot.py
@@ -6,15 +6,24 @@ import json
 import os
 
 import asyncio
+import base64
+import io
+import math
+
 import nest_asyncio
 import yt_dlp as youtube_dl
 import discord
 from discord.ext import commands
+from PIL import Image
 from systemd import journal
+import aiohttp
 import re
 
 nest_asyncio.apply()
 logging.basicConfig(filename="farsbot.log", level=logging.DEBUG)
+
+FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second."
+OPENROUTER_MODEL = "google/gemini-3.1-flash-image-preview"
 
 user_id_anders = 801923008532578354
 user_id_fritjof = 560877870076133378
@@ -95,10 +104,83 @@ def load_token(filename="token.json"):
     return js["token"]
 
 
+def load_openrouter_key(filename="openrouter.json"):
+    with open(filename) as handle:
+        js = json.load(handle)
+    return js["api_key"]
+
+
+def synthesize_face_grid(faces_dir="faces"):
+    image_files = glob.glob("{}/*.*".format(faces_dir))
+    if not image_files:
+        return None
+    images = [Image.open(f) for f in image_files]
+    max_w = max(img.width for img in images)
+    max_h = max(img.height for img in images)
+    cols = math.ceil(math.sqrt(len(images)))
+    rows = math.ceil(len(images) / cols)
+    grid = Image.new("RGBA", (cols * max_w, rows * max_h), (0, 0, 0, 0))
+    for idx, img in enumerate(images):
+        col = idx % cols
+        row = idx // cols
+        x = col * max_w + (max_w - img.width) // 2
+        y = row * max_h + (max_h - img.height) // 2
+        grid.paste(img, (x, y))
+    return grid
+
+
+def image_to_base64_uri(img):
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return "data:image/png;base64,{}".format(b64)
+
+
+def bytes_to_base64_uri(data, content_type="image/png"):
+    b64 = base64.b64encode(data).decode("utf-8")
+    return "data:{};base64,{}".format(content_type, b64)
+
+
+async def call_openrouter(api_key, original_image_uri, grid_image_uri, prompt):
+    payload = {
+        "model": OPENROUTER_MODEL,
+        "modalities": ["image", "text"],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": original_image_uri}},
+                    {"type": "image_url", "image_url": {"url": grid_image_uri}},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    }
+    headers = {
+        "Authorization": "Bearer {}".format(api_key),
+        "Content-Type": "application/json",
+    }
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            json=payload,
+            headers=headers,
+        ) as resp:
+            result = await resp.json()
+    images = result["choices"][0]["message"].get("images", [])
+    if not images:
+        return None
+    b64_url = images[0]["image_url"]["url"]
+    # Strip the data URI prefix
+    b64_data = b64_url.split(",", 1)[1]
+    return base64.b64decode(b64_data)
+
+
 class FarsBot(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.queue = []
+        self.openrouter_key = load_openrouter_key()
 
     def check_queue(self, client):
         if len(self.queue) > 0:
@@ -260,6 +342,54 @@ class FarsBot(commands.Cog):
     async def highfive(self, ctx, category=""):
         await ctx.channel.send(
             file=discord.File(get_reaction_image_with_name("highfive.png"))
+        )
+
+    @commands.command()
+    async def faxify(self, ctx):
+        if not ctx.message.reference:
+            await ctx.send("Du måste svara på ett meddelande med en bild.")
+            return
+        ref_msg = await ctx.channel.fetch_message(ctx.message.reference.message_id)
+        image_url = None
+        content_type = "image/png"
+        for att in ref_msg.attachments:
+            if att.content_type and att.content_type.startswith("image/"):
+                image_url = att.url
+                content_type = att.content_type
+                break
+        if not image_url:
+            for embed in ref_msg.embeds:
+                if embed.image:
+                    image_url = embed.image.url
+                    break
+                if embed.thumbnail:
+                    image_url = embed.thumbnail.url
+                    break
+        if not image_url:
+            await ctx.send("Kunde inte hitta en bild i det meddelandet.")
+            return
+        async with aiohttp.ClientSession() as session:
+            async with session.get(image_url) as resp:
+                original_bytes = await resp.read()
+        grid_img = synthesize_face_grid()
+        if grid_img is None:
+            await ctx.send("Inga bilder hittades i faces-mappen.")
+            return
+        original_uri = bytes_to_base64_uri(original_bytes, content_type)
+        grid_uri = image_to_base64_uri(grid_img)
+        try:
+            result_bytes = await call_openrouter(
+                self.openrouter_key, original_uri, grid_uri, FAXIFY_PROMPT
+            )
+        except Exception as e:
+            logging.error("Faxify OpenRouter error: %s", e)
+            await ctx.send("Något gick fel med faxifieringen.")
+            return
+        if not result_bytes:
+            await ctx.send("Modellen returnerade ingen bild.")
+            return
+        await ctx.send(
+            file=discord.File(io.BytesIO(result_bytes), filename="faxified.png")
         )
 
     @commands.command()

--- a/farsbot.py
+++ b/farsbot.py
@@ -21,7 +21,7 @@ import re
 
 nest_asyncio.apply()
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     handlers=[
         logging.FileHandler("farsbot.log"),
         logging.StreamHandler(),
@@ -116,11 +116,18 @@ def load_openrouter_key(filename="openrouter.json"):
     return js["api_key"]
 
 
+FACE_TILE_MAX = 256
+
+
 def synthesize_face_grid(faces_dir="faces"):
     image_files = glob.glob("{}/*.*".format(faces_dir))
     if not image_files:
         return None
-    images = [Image.open(f).convert("RGBA") for f in image_files]
+    images = []
+    for f in image_files:
+        img = Image.open(f).convert("RGBA")
+        img.thumbnail((FACE_TILE_MAX, FACE_TILE_MAX), Image.LANCZOS)
+        images.append(img)
     max_w = max(img.width for img in images)
     max_h = max(img.height for img in images)
     cols = math.ceil(math.sqrt(len(images)))
@@ -135,16 +142,30 @@ def synthesize_face_grid(faces_dir="faces"):
     return grid
 
 
+MAX_IMAGE_DIMENSION = 2048
+
+
+def downscale_image(img, max_dim=MAX_IMAGE_DIMENSION):
+    if max(img.size) > max_dim:
+        img.thumbnail((max_dim, max_dim), Image.LANCZOS)
+    return img
+
+
 def image_to_base64_uri(img):
+    img = downscale_image(img.copy())
     buf = io.BytesIO()
     img.save(buf, format="PNG")
     b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
     return "data:image/png;base64,{}".format(b64)
 
 
-def bytes_to_base64_uri(data, content_type="image/png"):
-    b64 = base64.b64encode(data).decode("utf-8")
-    return "data:{};base64,{}".format(content_type, b64)
+def bytes_to_base64_uri(data):
+    img = Image.open(io.BytesIO(data))
+    img = downscale_image(img)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("utf-8")
+    return "data:image/png;base64,{}".format(b64)
 
 
 async def call_openrouter(api_key, image_urls, prompt):
@@ -392,12 +413,11 @@ class FarsBot(commands.Cog):
         async with aiohttp.ClientSession() as session:
             async with session.get(image_url) as resp:
                 original_bytes = await resp.read()
-                content_type = resp.content_type or "image/png"
         grid_img = synthesize_face_grid()
         if grid_img is None:
             await ctx.send("Inga bilder hittades i faces-mappen.")
             return
-        original_uri = bytes_to_base64_uri(original_bytes, content_type)
+        original_uri = bytes_to_base64_uri(original_bytes)
         grid_uri = image_to_base64_uri(grid_img)
         try:
             result_bytes = await call_openrouter(

--- a/farsbot.py
+++ b/farsbot.py
@@ -169,7 +169,7 @@ async def call_openrouter(api_key, original_image_uri, grid_image_uri, prompt):
             result = await resp.json()
     images = result["choices"][0]["message"].get("images", [])
     if not images:
-        logging.warning("OpenRouter returned no images. Response: %s", result)
+        print("OpenRouter returned no images. Response: {}".format(result))
         return None
     b64_url = images[0]["image_url"]["url"]
     # Strip the data URI prefix

--- a/farsbot.py
+++ b/farsbot.py
@@ -28,7 +28,7 @@ logging.basicConfig(
     ],
 )
 
-FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second. Each face in the first image should be replace with exactly one face from the second image. Remove background from the faces in the second image if needed."
+FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second. Each face in the first image should be replace with exactly one face from the second image. Remove background from the faces in the second image if needed. Do not change anything else in the first image."
 OPENROUTER_MODEL = "bytedance-seed/seedream-4.5"
 
 user_id_anders = 801923008532578354

--- a/farsbot.py
+++ b/farsbot.py
@@ -20,7 +20,13 @@ import aiohttp
 import re
 
 nest_asyncio.apply()
-logging.basicConfig(filename="farsbot.log", level=logging.DEBUG)
+logging.basicConfig(
+    level=logging.DEBUG,
+    handlers=[
+        logging.FileHandler("farsbot.log"),
+        logging.StreamHandler(),
+    ],
+)
 
 FAXIFY_PROMPT = "Replace all the faces in the first image with random ones from the second. Each face in the first image should be replace with exactly one face from the second image. Remove background from the faces in the second image if needed."
 OPENROUTER_MODEL = "bytedance-seed/seedream-4.5"
@@ -401,7 +407,7 @@ class FarsBot(commands.Cog):
 
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
-        print(f"Voice state update: member={member} (bot={member.bot}), before={before.channel}, after={after.channel}")
+        logging.info(f"Voice state update: member={member} (bot={member.bot}), before={before.channel}, after={after.channel}")
         # Ignore bot's own voice state changes
         if member.bot:
             return
@@ -533,7 +539,7 @@ bot = commands.Bot(
 
 @bot.event
 async def on_ready():
-    print(f"Bot ready. Guilds: {[g.name for g in bot.guilds]}. Cogs: {list(bot.cogs.keys())}")
+    logging.info(f"Bot ready. Guilds: {[g.name for g in bot.guilds]}. Cogs: {list(bot.cogs.keys())}")
 
 
 async def main():
@@ -541,7 +547,7 @@ async def main():
 
     async with bot:
         await bot.add_cog(FarsBot(bot))
-        print(f"Cog added. Listeners: {bot.extra_events}")
+        logging.info(f"Cog added. Listeners: {bot.extra_events}")
         await bot.start(t)
 
 

--- a/farsbot.py
+++ b/farsbot.py
@@ -147,16 +147,15 @@ def bytes_to_base64_uri(data, content_type="image/png"):
     return "data:{};base64,{}".format(content_type, b64)
 
 
-async def call_openrouter(api_key, original_image_uri, grid_image_uri, prompt):
+async def call_openrouter(api_key, image_urls, prompt):
     payload = {
         "model": OPENROUTER_MODEL,
-        "modalities": ["image", "text"],
+        "modalities": ["image"],
         "messages": [
             {
                 "role": "user",
                 "content": [
-                    {"type": "image_url", "image_url": {"url": original_image_uri}},
-                    {"type": "image_url", "image_url": {"url": grid_image_uri}},
+                    *[{"type": "image_url", "image_url": {"url": url}} for url in image_urls],
                     {"type": "text", "text": prompt},
                 ],
             }
@@ -173,14 +172,26 @@ async def call_openrouter(api_key, original_image_uri, grid_image_uri, prompt):
             headers=headers,
         ) as resp:
             result = await resp.json()
-    images = result["choices"][0]["message"].get("images", [])
-    if not images:
-        print("OpenRouter returned no images. Response: {}".format(result))
+    logging.info("OpenRouter response: %s", result)
+    choices = result.get("choices", [])
+    if not choices:
+        logging.error("OpenRouter returned no choices. Response: %s", result)
         return None
-    b64_url = images[0]["image_url"]["url"]
-    # Strip the data URI prefix
-    b64_data = b64_url.split(",", 1)[1]
-    return base64.b64decode(b64_data)
+    message = choices[0].get("message", {})
+    # Try images field (Gemini-style response)
+    images = message.get("images", [])
+    if images:
+        b64_url = images[0]["image_url"]["url"]
+        b64_data = b64_url.split(",", 1)[1]
+        return base64.b64decode(b64_data)
+    # Try inline base64 in content (Seedream-style response)
+    content = message.get("content", "")
+    if "data:image" in content:
+        b64_url = content.strip()
+        b64_data = b64_url.split(",", 1)[1]
+        return base64.b64decode(b64_data)
+    logging.error("OpenRouter returned no images. Response: %s", result)
+    return None
 
 
 class FarsBot(commands.Cog):
@@ -359,11 +370,9 @@ class FarsBot(commands.Cog):
             return
         ref_msg = await ctx.channel.fetch_message(ctx.message.reference.message_id)
         image_url = None
-        content_type = "image/png"
         for att in ref_msg.attachments:
             if att.content_type and att.content_type.startswith("image/"):
                 image_url = att.url
-                content_type = att.content_type
                 break
         if not image_url:
             for embed in ref_msg.embeds:
@@ -376,18 +385,14 @@ class FarsBot(commands.Cog):
         if not image_url:
             await ctx.send("Kunde inte hitta en bild i det meddelandet.")
             return
-        async with aiohttp.ClientSession() as session:
-            async with session.get(image_url) as resp:
-                original_bytes = await resp.read()
         grid_img = synthesize_face_grid()
         if grid_img is None:
             await ctx.send("Inga bilder hittades i faces-mappen.")
             return
-        original_uri = bytes_to_base64_uri(original_bytes, content_type)
         grid_uri = image_to_base64_uri(grid_img)
         try:
             result_bytes = await call_openrouter(
-                self.openrouter_key, original_uri, grid_uri, FAXIFY_PROMPT
+                self.openrouter_key, [image_url, grid_uri], FAXIFY_PROMPT
             )
         except Exception as e:
             logging.error("Faxify OpenRouter error: %s", e)

--- a/farsbot.py
+++ b/farsbot.py
@@ -531,12 +531,18 @@ bot = commands.Bot(
 )
 
 
+@bot.event
+async def on_ready():
+    print(f"Bot ready. Guilds: {[g.name for g in bot.guilds]}. Cogs: {list(bot.cogs.keys())}")
+
+
 async def main():
     t = load_token()
 
     async with bot:
         await bot.add_cog(FarsBot(bot))
-        await bot.run(t)
+        print(f"Cog added. Listeners: {bot.extra_events}")
+        await bot.start(t)
 
 
 if __name__ == "__main__":

--- a/farsbot.py
+++ b/farsbot.py
@@ -401,6 +401,7 @@ class FarsBot(commands.Cog):
 
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
+        print(f"Voice state update: member={member} (bot={member.bot}), before={before.channel}, after={after.channel}")
         # Ignore bot's own voice state changes
         if member.bot:
             return

--- a/farsbot.py
+++ b/farsbot.py
@@ -120,7 +120,7 @@ def synthesize_face_grid(faces_dir="faces"):
     image_files = glob.glob("{}/*.*".format(faces_dir))
     if not image_files:
         return None
-    images = [Image.open(f) for f in image_files]
+    images = [Image.open(f).convert("RGBA") for f in image_files]
     max_w = max(img.width for img in images)
     max_h = max(img.height for img in images)
     cols = math.ceil(math.sqrt(len(images)))
@@ -171,6 +171,10 @@ async def call_openrouter(api_key, image_urls, prompt):
             json=payload,
             headers=headers,
         ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                logging.error("OpenRouter HTTP %s: %s", resp.status, body[:500])
+                return None
             result = await resp.json()
     logging.info("OpenRouter response: %s", result)
     choices = result.get("choices", [])

--- a/farsbot.py
+++ b/farsbot.py
@@ -389,14 +389,19 @@ class FarsBot(commands.Cog):
         if not image_url:
             await ctx.send("Kunde inte hitta en bild i det meddelandet.")
             return
+        async with aiohttp.ClientSession() as session:
+            async with session.get(image_url) as resp:
+                original_bytes = await resp.read()
+                content_type = resp.content_type or "image/png"
         grid_img = synthesize_face_grid()
         if grid_img is None:
             await ctx.send("Inga bilder hittades i faces-mappen.")
             return
+        original_uri = bytes_to_base64_uri(original_bytes, content_type)
         grid_uri = image_to_base64_uri(grid_img)
         try:
             result_bytes = await call_openrouter(
-                self.openrouter_key, [image_url, grid_uri], FAXIFY_PROMPT
+                self.openrouter_key, [original_uri, grid_uri], FAXIFY_PROMPT
             )
         except Exception as e:
             logging.error("Faxify OpenRouter error: %s", e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ urllib3==2.2.2
 websockets==12.0
 yarl==1.20.1
 yt-dlp==2024.8.1
+Pillow>=10.0.0


### PR DESCRIPTION
This pull request introduces a new "faxify" feature to the Discord bot, allowing users to replace faces in an image with random faces from a local collection using an external AI model. It also improves logging, adds support for the OpenRouter API, and includes several utility functions for image processing. The most important changes are summarized below.

### New "faxify" feature and OpenRouter integration

* Added the `faxify` command to the bot, which lets users reply to a message containing an image and have the faces in that image replaced with random faces from a local folder using the OpenRouter AI model. This includes robust error handling and user feedback.
* Implemented several utility functions for image processing (`synthesize_face_grid`, `downscale_image`, `image_to_base64_uri`, `bytes_to_base64_uri`) and a function to call the OpenRouter API (`call_openrouter`), enabling the bot to prepare images and interact with the external service.
* Added a configuration file `.claude/settings.local.json` to allow the bot to fetch data from the OpenRouter domain.

### Logging and stability improvements

* Enhanced logging throughout the bot, including startup logs, voice state updates, and error handling for external API calls, making debugging and monitoring easier. [[1]](diffhunk://#diff-d8ce34bb11172cc440e79c8a6bf60076f6d8be789fbe2abc3ca66c45865e7d67R9-R32) [[2]](diffhunk://#diff-d8ce34bb11172cc440e79c8a6bf60076f6d8be789fbe2abc3ca66c45865e7d67R574-R585)
* Improved voice channel connection logic by preventing duplicate connection attempts and ensuring proper state management with the `_voice_connecting` flag. [[1]](diffhunk://#diff-d8ce34bb11172cc440e79c8a6bf60076f6d8be789fbe2abc3ca66c45865e7d67R463-R465) [[2]](diffhunk://#diff-d8ce34bb11172cc440e79c8a6bf60076f6d8be789fbe2abc3ca66c45865e7d67R486-R487)